### PR TITLE
fix: GET /health 엔드포인트 응답에 uptime_seconds 필드 추가

### DIFF
--- a/__tests__/health.test.js
+++ b/__tests__/health.test.js
@@ -53,4 +53,16 @@ describe('GET /health', () => {
       expect(res.body.response_time_ms).toBeGreaterThanOrEqual(0);
     }
   });
+
+  it('uptime_seconds 필드가 존재해야 한다', async () => {
+    const res = await request(app).get('/health');
+    expect(res.body).toHaveProperty('uptime_seconds');
+  });
+
+  it('uptime_seconds는 0 이상의 정수여야 한다', async () => {
+    const res = await request(app).get('/health');
+    expect(typeof res.body.uptime_seconds).toBe('number');
+    expect(Number.isInteger(res.body.uptime_seconds)).toBe(true);
+    expect(res.body.uptime_seconds).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ app.get('/health', (req, res) => {
   const payload = {
     status: 'ok',
     uptime: process.uptime(),
+    uptime_seconds: Math.floor(process.uptime()),
   };
 
   const end = process.hrtime.bigint();


### PR DESCRIPTION
Closes #8

## Changes
- `app.js`: `/health` 응답에 `uptime_seconds` 필드 추가 (`Math.floor(process.uptime())`)
- `__tests__/health.test.js`: `uptime_seconds` 필드 존재 및 정수 타입 검증 테스트 2개 추가

## Test Results
- 10 tests passed (기존 8개 + 신규 2개)
- 모든 기존 필드(`status`, `uptime`, `response_time_ms`) 유지 확인

🤖 Generated by APEX